### PR TITLE
fix: replace aside with note

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -44,8 +44,8 @@ Click **Next**.
 
 Copy and run the generated Docker command to start monitoring the database server. The data will start flowing right away.
 
-<aside>
+:::note
 ❗ It might take 2-3 minutes to see the data.
-</aside>
+:::
   
 Go back to the page [Monitoring](https://app.metisdata.io/monitoring). The new monitored database server can be found there.


### PR DESCRIPTION
Due to aside tag, hyperlink was not working on Monitoring

<img width="1202" alt="Quickstart! | Metis 2024-02-24 13-39-34" src="https://github.com/metis-data/metis-book/assets/39362422/059a553f-b24a-4073-b07a-b6dffb37e8a1">

Now with `note` [admonitions](https://docusaurus.io/docs/markdown-features/admonitions)
<img width="1114" alt="Quickstart! | Metis 2024-02-24 13-52-06" src="https://github.com/metis-data/metis-book/assets/39362422/2612a297-f325-4d9e-b37e-cc6ee6a45912">
